### PR TITLE
#5 hotfix

### DIFF
--- a/irucapy/__init__.py
+++ b/irucapy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 from . import \
     dataclassutil,exceptions,types,\
     room,member,members,\

--- a/irucapy/member.py
+++ b/irucapy/member.py
@@ -14,7 +14,7 @@ class Member:
     room_id: int
     name: str
     status: str
-    message: str
+    message: Optional[str]
     created_at: ISO8601Text
     updated_at: ISO8601Text
     position: int

--- a/irucapy/member.py
+++ b/irucapy/member.py
@@ -11,6 +11,7 @@ class Member:
     The response template for the `メンバー情報取得API`.
     Reference: https://iruca.co/api
     """
+
     id: int
     room_id: int
     name: str

--- a/irucapy/member.py
+++ b/irucapy/member.py
@@ -2,6 +2,7 @@ from .types import ISO8601Text
 from typing import Optional
 from dataclasses import dataclass
 from . import dataclassutil
+import json
 
 
 @dataclass
@@ -22,3 +23,17 @@ class Member:
 
 def from_json_maybe(json_text: str) -> Optional[Member]:
     return dataclassutil.from_json_maybe(json_text, Member)
+def from_json_object_maybe(o: object) -> Optional[Member]:
+    try:
+        return Member(
+            id=o["id"],
+            room_id=o["room_id"],
+            name=o["name"],
+            status=o["status"],
+            message=o["message"],
+            created_at=o["created_at"],
+            updated_at=o["updated_at"],
+            position=o["position"],
+        )
+    except:
+        return None

--- a/irucapy/member.py
+++ b/irucapy/member.py
@@ -22,7 +22,9 @@ class Member:
 
 
 def from_json_maybe(json_text: str) -> Optional[Member]:
-    return dataclassutil.from_json_maybe(json_text, Member)
+    return from_json_object_maybe(json.loads(json_text))
+
+
 def from_json_object_maybe(o: object) -> Optional[Member]:
     try:
         return Member(

--- a/irucapy/members.py
+++ b/irucapy/members.py
@@ -9,7 +9,7 @@ def from_json_maybe(json_text: str) -> Optional[member.Member]:
         obj = []
         data = json.loads(json_text)
         for member_data in data:
-            member_obj_maybe = dataclassutil.from_data_maybe(member_data, member.Member)
+            member_obj_maybe = member.from_json_object_maybe(member_data)
             if member_obj_maybe is not None:
                 obj.append(member_obj_maybe)
         return obj


### PR DESCRIPTION
Type `Member` didn't allow `messaage` data to be None. This update allows `message` data to be None.