### PR TITLE
#7 hotfix

### DIFF
--- a/irucapy/__init__.py
+++ b/irucapy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 from . import \
     dataclassutil,exceptions,types,\
     room,member,members,\

--- a/irucapy/httpirucaapi.py
+++ b/irucapy/httpirucaapi.py
@@ -81,7 +81,12 @@ class HTTPIrucaAPI(IrucaAPI):
     def update_room_member(self, room_code: str, member_id: int, param: MemberUpdateParam) -> None:
         url: str = f"{self.get_room_url(room_code)}/members/{member_id}"
         try:
-            data = json.dumps(asdict(param)).encode()
+            data_object = {"status":param.status}
+            if param.name is not None:
+                data_object["name"] = param.name
+            if param.message is not None:
+                data_object["message"] = param.message
+            data = json.dumps(data_object).encode()
             request = Request(url, data=data, headers={
                               "Content-Type": "application/json"}, method="PUT")
             with urlopen(request) as res:

--- a/tests/httpirucaapi.py
+++ b/tests/httpirucaapi.py
@@ -25,7 +25,9 @@ def get_room_member():
 def update_room_member():
     member_id = int(input("MEMBER ID: "))
     status = input("STATUS: ")
-    param = irucapy.memberupdate.MemberUpdateParam(status, None, None)
+    message_input = input("MESSAGE(none for None): ")
+    message = None if message_input=="none" else message_input
+    param = irucapy.memberupdate.MemberUpdateParam(status, None, message)
     api.update_room_member(room_code, member_id, param)
 
 


### PR DESCRIPTION
メンバー情報更新APIでは、ひとことを変更しない場合はリクエストデータに`message`フィールドを含めないことになっている。`HTTPIrucaAPI#update_room_member`にて、与えられた`MemberUpdateParam#message`がNoneの場合、それはひとことを更新しないことを主張しているので、リクエストデータに`message`フィールドを生成しないようにした。　